### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/libopencv4android/opencv2/contrib/contrib.hpp
+++ b/libopencv4android/opencv2/contrib/contrib.hpp
@@ -649,7 +649,7 @@ namespace cv
     *of the four nearest neighbouring Cartesian pixels to the center of the RF.
     *The same principle is applied to the inverse transformation.
     *
-    *More details can be found in http://dx.doi.org/10.1007/978-3-642-23968-7_5
+    *More details can be found in https://doi.org/10.1007/978-3-642-23968-7_5
     */
     class CV_EXPORTS LogPolar_Interp
     {
@@ -714,7 +714,7 @@ namespace cv
     *The fovea (oversampling) is handled by using the bilinear interpolation technique described above, whereas in
     *the periphery we use the overlapping Gaussian circular RFs.
     *
-    *More details can be found in http://dx.doi.org/10.1007/978-3-642-23968-7_5
+    *More details can be found in https://doi.org/10.1007/978-3-642-23968-7_5
     */
     class CV_EXPORTS LogPolar_Overlapping
     {
@@ -788,7 +788,7 @@ namespace cv
     *This technique is implemented from: Traver, V., Pla, F.: Log-polar mapping template design: From task-level requirements
     *to geometry parameters. Image Vision Comput. 26(10) (2008) 1354-1370
     *
-    *More details can be found in http://dx.doi.org/10.1007/978-3-642-23968-7_5
+    *More details can be found in https://doi.org/10.1007/978-3-642-23968-7_5
     */
     class CV_EXPORTS LogPolar_Adjacent
     {

--- a/libopencv4android/opencv2/contrib/retina.hpp
+++ b/libopencv4android/opencv2/contrib/retina.hpp
@@ -16,7 +16,7 @@
  **
  ** Theses algorithm have been developped by Alexandre BENOIT since his thesis with Alice Caplier at Gipsa-Lab (www.gipsa-lab.inpg.fr) and the research he pursues at LISTIC Lab (www.listic.univ-savoie.fr).
  ** Refer to the following research paper for more information:
- ** Benoit A., Caplier A., Durette B., Herault, J., "USING HUMAN VISUAL SYSTEM MODELING FOR BIO-INSPIRED LOW LEVEL IMAGE PROCESSING", Elsevier, Computer Vision and Image Understanding 114 (2010), pp. 758-773, DOI: http://dx.doi.org/10.1016/j.cviu.2010.01.011
+ ** Benoit A., Caplier A., Durette B., Herault, J., "USING HUMAN VISUAL SYSTEM MODELING FOR BIO-INSPIRED LOW LEVEL IMAGE PROCESSING", Elsevier, Computer Vision and Image Understanding 114 (2010), pp. 758-773, DOI: https://doi.org/10.1016/j.cviu.2010.01.011
  ** This work have been carried out thanks to Jeanny Herault who's research and great discussions are the basis of all this work, please take a look at his book:
  ** Vision: Images, Signals and Neural Networks: Models of Neural Processing in Visual Perception (Progress in Neural Processing),By: Jeanny Herault, ISBN: 9814273686. WAPI (Tower ID): 113266891.
  **
@@ -101,7 +101,7 @@ class RetinaFilter;
  *      _using the getMagno method output matrix : motion analysis also with the previously cited properties
  *
  * for more information, reer to the following papers :
- * Benoit A., Caplier A., Durette B., Herault, J., "USING HUMAN VISUAL SYSTEM MODELING FOR BIO-INSPIRED LOW LEVEL IMAGE PROCESSING", Elsevier, Computer Vision and Image Understanding 114 (2010), pp. 758-773, DOI: http://dx.doi.org/10.1016/j.cviu.2010.01.011
+ * Benoit A., Caplier A., Durette B., Herault, J., "USING HUMAN VISUAL SYSTEM MODELING FOR BIO-INSPIRED LOW LEVEL IMAGE PROCESSING", Elsevier, Computer Vision and Image Understanding 114 (2010), pp. 758-773, DOI: https://doi.org/10.1016/j.cviu.2010.01.011
  * Vision: Images, Signals and Neural Networks: Models of Neural Processing in Visual Perception (Progress in Neural Processing),By: Jeanny Herault, ISBN: 9814273686. WAPI (Tower ID): 113266891.
  *
  * The retina filter includes the research contributions of phd/research collegues from which code has been redrawn by the author :
@@ -230,7 +230,7 @@ public:
      * setup the OPL and IPL parvo channels (see biologocal model)
      * OPL is referred as Outer Plexiform Layer of the retina, it allows the spatio-temporal filtering which withens the spectrum and reduces spatio-temporal noise while attenuating global luminance (low frequency energy)
      * IPL parvo is the OPL next processing stage, it refers to Inner Plexiform layer of the retina, it allows high contours sensitivity in foveal vision.
-     * for more informations, please have a look at the paper Benoit A., Caplier A., Durette B., Herault, J., "USING HUMAN VISUAL SYSTEM MODELING FOR BIO-INSPIRED LOW LEVEL IMAGE PROCESSING", Elsevier, Computer Vision and Image Understanding 114 (2010), pp. 758-773, DOI: http://dx.doi.org/10.1016/j.cviu.2010.01.011
+     * for more informations, please have a look at the paper Benoit A., Caplier A., Durette B., Herault, J., "USING HUMAN VISUAL SYSTEM MODELING FOR BIO-INSPIRED LOW LEVEL IMAGE PROCESSING", Elsevier, Computer Vision and Image Understanding 114 (2010), pp. 758-773, DOI: https://doi.org/10.1016/j.cviu.2010.01.011
      * @param colorMode : specifies if (true) color is processed of not (false) to then processing gray level image
      * @param normaliseOutput : specifies if (true) output is rescaled between 0 and 255 of not (false)
      * @param photoreceptorsLocalAdaptationSensitivity: the photoreceptors sensitivity renage is 0-1 (more log compression effect when value increases)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update all static DOI links.

Cheers!